### PR TITLE
General fixes and packaging adjustments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,9 @@ Removed
 
 * Python 2.7 support removed.
 
+* ``flake8`` package removed as a dependency since Flake8-AAA can be run on a
+  command line without it.
+
 0.4.0_ - 2018/07/17
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -45,15 +45,16 @@ Install with ``pip``::
 Integration with Flake8
 -----------------------
 
-Check that Flake8-AAA was installed correctly by asking ``flake8`` for its
-version signature::
+Given that you already have Flake8 installed in the same environment, check
+that Flake8-AAA was installed correctly by asking ``flake8`` for its version
+signature::
 
     $ flake8 --version
-    3.5.0 (aaa: 0.4.0, mccabe: 0.6.1, pycodestyle: 2.3.1, pyflakes: 1.6.0) CPython 3.5.2 on Linux
+    3.6.0 (aaa: 0.4.0, mccabe: 0.6.1, pycodestyle: 2.4.0, pyflakes: 2.0.0) CPython 3.6.7 on Linux
 
-The ``aaa: 0.4.0`` part of that output tells you ``flake8`` found this plugin.
-Now you can run ``flake8`` as usual against your project and Flake8-AAA will
-lint your tests::
+The ``(aaa: 0.4.0, ...`` part of that output tells you ``flake8`` found this
+plugin. Now you can run ``flake8`` as usual against your project and Flake8-AAA
+will lint your tests via its plugin::
 
     $ flake8
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ with open(os.path.join(basedir, 'flake8_aaa', '__about__.py')) as f:
 
 # -- Project information -----------------------------------------------------
 
-project = about['__name__']
+project = about['__iam__']
 copyright = about['__copyright__']
 author = about['__author__']
 

--- a/flake8_aaa/checker.py
+++ b/flake8_aaa/checker.py
@@ -9,7 +9,7 @@ from .function import Function
 from .helpers import find_test_functions, is_test_file
 
 
-class Checker(object):
+class Checker:
     """
     Attributes:
         ast_tokens (asttokens.ASTTokens): Tokens for the file.

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
     # --- Python ---
     packages=['flake8_aaa'],
     py_modules=['flake8_aaa'],
+    python_requires='>=3.5, <4',
     install_requires=[
         'asttokens >= 1.1.10',
-        'flake8 >= 3',
     ],
     entry_points={
         'flake8.extension': [

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,20 @@
 #   flake8-aaa - the latest version is installed by tox during testing.
 # test = run pytest
 # lint = run all linting, including on the test suite
+# cmd = run the command line interface (no flake8 installed, just flake8-aaa)
 
 [tox]
-envlist = py{35,36}-{install,test,lint}
+envlist = py{35,36}-{install,test,lint,cmd}
 [testenv]
-deps = -rrequirements/test.txt
+deps =
+    install: flake8>=3
+    test,lint: -rrequirements/test.txt
 commands =
     install: flake8 --version
     install: flake8 tests examples/good
     test: pytest tests
     lint: make lint
+    cmd: python -m flake8_aaa examples/good/test_account_edit_view.py
+    cmd: python -m flake8_aaa examples/good/test_django_fakery_factories.py
 setenv = IN_TOX = 1
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 # install = Assert that plugin can be installed and run via flake8 in a clean
 #   venv. Flake8 is called with flake8-aaa installed to lint flake8-aaa's tests
-#   and the "good" examples
+#   and the "good" examples (dog fooding). Test requirements do not include
+#   flake8-aaa - the latest version is installed by tox during testing.
 # test = run pytest
-# lint = run all linting, including on the test suite. Use both py2 and py3 to
-#   ensure that unicode loads OK.
+# lint = run all linting, including on the test suite
 
 [tox]
 envlist = py{35,36}-{install,test,lint}


### PR DESCRIPTION
* Python 3 now required by `setup.py`.

* Flake8 no longer installed as a dependency.

* New command line functionality tested by tox with a "pure" environment - only `flake8_aaa` is installed.