### PR TITLE
Adjust Travis to run all envs for each Python found in tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
-matrix:
-    include:
-        - python: 3.5
-          env: TOXENV=py35-install,py35-test,py35-lint,py35-doc
-        - python: 3.6
-          env: TOXENV=py36-install,py36-test,py36-lint
+python:
+    - "3.5"
+    - "3.6"
 install: pip install tox
-script: tox
+script:
+    - TOXENV=$(tox --listenvs | grep "py${TRAVIS_PYTHON_VERSION/./}-" | tr '\n' ',')
+    - export TOXENV
+    - tox


### PR DESCRIPTION
Travis was not running either of the cmd environments because that environment had been missed from the `.travis.yml`.

Instead, adjust to using the workaround outlined on https://github.com/tox-dev/tox/issues/318 until some form of globbing is available.