### PR TITLE
Clean up error and exception control flow

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -136,6 +136,7 @@ disable=print-statement,
         comprehension-escape,
         # Ignore missing docstrings until this is merged: https://github.com/PyCQA/pylint/issues/1164
         missing-docstring,
+        bad-continuation,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/flake8_aaa/checker.py
+++ b/src/flake8_aaa/checker.py
@@ -48,6 +48,7 @@ class Checker:
             self.load()
             for func in self.all_funcs():
                 try:
-                    yield from func.check_all()
+                    for error in func.check_all():
+                        yield (error.line_number, error.offset, error.text, Checker)
                 except ValidationError as error:
                     yield error.to_flake8(Checker)

--- a/src/flake8_aaa/checker.py
+++ b/src/flake8_aaa/checker.py
@@ -4,6 +4,7 @@ from typing import Generator, List, Tuple
 import asttokens
 
 from .__about__ import __short_name__, __version__
+from .exceptions import ValidationError
 from .function import Function
 from .helpers import find_test_functions, is_test_file
 
@@ -46,4 +47,7 @@ class Checker:
         if is_test_file(self.filename):
             self.load()
             for func in self.all_funcs():
-                yield from func.check_all(type(self))
+                try:
+                    yield from func.check_all()
+                except ValidationError as error:
+                    yield error.to_flake8(Checker)

--- a/src/flake8_aaa/command_line.py
+++ b/src/flake8_aaa/command_line.py
@@ -1,10 +1,11 @@
 import ast
-from typing import IO
+import typing
 
 from .checker import Checker
+from .exceptions import AAAError, ValidationError
 
 
-def do_command_line(infile: IO[str]) -> int:
+def do_command_line(infile: typing.IO[str]) -> int:
     """
     Currently a small stub to create an instance of Checker for the passed
     ``infile`` and run its test functions through linting.
@@ -19,8 +20,11 @@ def do_command_line(infile: IO[str]) -> int:
     tree = ast.parse(''.join(lines))
     checker = Checker(tree, lines, infile.name)
     checker.load()
-    errors = []  # type: list
+    errors = []  # type: typing.List[AAAError]
     for func in checker.all_funcs(skip_noqa=True):
-        errors = list(func.check_all(type(do_command_line)))
+        try:
+            errors = list(func.check_all())
+        except ValidationError as error:
+            errors = [error.to_aaa()]
         print(func.__str__(errors), end='')
     return len(errors)

--- a/src/flake8_aaa/exceptions.py
+++ b/src/flake8_aaa/exceptions.py
@@ -9,6 +9,12 @@ Flake8Error = typing.NamedTuple(
     ]
 )
 
+AAAError = typing.NamedTuple('AAAError', [
+    ('line_number', int),
+    ('offset', int),
+    ('text', str),
+])
+
 
 class Flake8AAAException(Exception):
     pass
@@ -44,4 +50,11 @@ class ValidationError(Flake8AAAException):
             offset=self.offset,
             text=self.text,
             checker_cls=checker_cls,
+        )
+
+    def to_aaa(self) -> AAAError:
+        return AAAError(
+            line_number=self.line_number,
+            offset=self.offset,
+            text=self.text,
         )

--- a/src/flake8_aaa/line_markers.py
+++ b/src/flake8_aaa/line_markers.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Tuple, overload
+import typing
 
 from .exceptions import ValidationError
 from .types import LineType
@@ -14,12 +14,12 @@ class LineMarkers(list):
         super().__init__([LineType.unprocessed] * size)
         self.fn_offset = fn_offset  # type: int
 
-    @overload  # noqa: F811
-    def __setitem__(self, key: int, value: Any) -> None:
+    @typing.overload  # noqa: F811
+    def __setitem__(self, key: int, value: typing.Any) -> None:
         pass
 
-    @overload  # noqa: F811
-    def __setitem__(self, s: slice, o: Iterable) -> None:  # pylint: disable=function-redefined
+    @typing.overload  # noqa: F811
+    def __setitem__(self, s: slice, o: typing.Iterable) -> None:  # pylint: disable=function-redefined
         pass
 
     def __setitem__(self, key, value):  # noqa: F811 | pylint: disable=function-redefined
@@ -44,7 +44,7 @@ class LineMarkers(list):
             ))
         return super().__setitem__(key, value)
 
-    def update(self, span: Tuple[int, int], line_type: LineType) -> None:
+    def update(self, span: typing.Tuple[int, int], line_type: LineType) -> None:
         """
         Updates line types for a block's span.
 
@@ -65,6 +65,7 @@ class LineMarkers(list):
             except ValueError as error:
                 raise ValidationError(i + self.fn_offset, 1, 'AAA99 {}'.format(error))
 
+    # def check_arrange_act_spacing(self, checker_cls: type) -> typing.Generator[Flake8Error, None, None]:
     def check_arrange_act_spacing(self) -> None:
         """
         * When no spaces found, point error at line above act block

--- a/tests/function/test_check_all.py
+++ b/tests/function/test_check_all.py
@@ -2,7 +2,7 @@ from collections import Generator
 
 import pytest
 
-from flake8_aaa.checker import Checker
+from flake8_aaa.exceptions import AAAError
 
 
 @pytest.mark.parametrize(
@@ -14,7 +14,7 @@ from flake8_aaa.checker import Checker
     ids=['pass', 'docstring'],
 )
 def test_noop(function):
-    result = function.check_all(Checker)
+    result = function.check_all()
 
     assert isinstance(result, Generator)
     assert list(result) == []
@@ -38,7 +38,7 @@ def test(api_client, url):
     ]
 )
 def test_context_manager(function):
-    result = function.check_all(Checker)
+    result = function.check_all()
 
     assert isinstance(result, Generator)
     assert list(result) == []
@@ -68,15 +68,15 @@ def test_push(queue):
     ids=['no line before result= act', 'no line before marked act'],
 )
 def test_missing_space_before_act(function):
-    result = function.check_all(Checker)
+    result = function.check_all()
 
     assert isinstance(result, Generator)
     errors = list(result)
     assert len(errors) == 1
+    assert isinstance(errors[0], AAAError)
     assert errors[0].line_number == 3
     assert errors[0].offset == 0
     assert errors[0].text == 'AAA03 expected 1 blank line before Act block, found none'
-    assert errors[0].checker_cls is Checker
 
 
 @pytest.mark.parametrize(
@@ -100,7 +100,7 @@ def test_push(queue):
     ids=['no line before assert', 'no line before assert with marked act'],
 )
 def test_missing_space_before_assert(function):
-    result = function.check_all(Checker)
+    result = function.check_all()
 
     assert isinstance(result, Generator)
     errors = list(result)
@@ -108,7 +108,6 @@ def test_missing_space_before_assert(function):
     assert errors[0].line_number == 5
     assert errors[0].offset == 0
     assert errors[0].text == 'AAA04 expected 1 blank line before Assert block, found none'
-    assert errors[0].checker_cls is Checker
 
 
 @pytest.mark.parametrize(
@@ -125,7 +124,7 @@ def test_multi(function):
     """
     No space before or after act - two errors are returned
     """
-    result = function.check_all(Checker)
+    result = function.check_all()
 
     assert isinstance(result, Generator)
     errors = list(result)

--- a/tests/function/test_str.py
+++ b/tests/function/test_str.py
@@ -84,7 +84,7 @@ def test(file_resource):
     ]
 )
 def test_processed(function):
-    errors = list(function.check_all(None))
+    errors = list(function.check_all())
 
     result = function.__str__(errors)
 
@@ -114,7 +114,7 @@ def test():
 ''']
 )
 def test_multi_spaces(function):
-    errors = list(function.check_all(None))
+    errors = list(function.check_all())
 
     result = function.__str__(errors)
 
@@ -141,7 +141,7 @@ def test():
     assert result == 5
 '''])
 def test_multi_errors(function):
-    errors = list(function.check_all(None))
+    errors = list(function.check_all())
 
     result = function.__str__(errors)
 

--- a/tests/line_markers/test_check_arrange_act_spacing.py
+++ b/tests/line_markers/test_check_arrange_act_spacing.py
@@ -1,6 +1,6 @@
-import pytest
+from collections import Generator
 
-from flake8_aaa.exceptions import ValidationError
+from flake8_aaa.exceptions import AAAError
 from flake8_aaa.line_markers import LineMarkers
 from flake8_aaa.types import LineType
 
@@ -21,7 +21,8 @@ def test_comment_before_act():
 
     result = line_markers.check_arrange_act_spacing()
 
-    assert result is None
+    assert isinstance(result, Generator)
+    assert list(result) == []
 
 
 def test_no_arrange():
@@ -39,7 +40,8 @@ def test_no_arrange():
 
     result = line_markers.check_arrange_act_spacing()
 
-    assert result is None
+    assert isinstance(result, Generator)
+    assert list(result) == []
 
 
 # --- FAILURES ---
@@ -57,12 +59,17 @@ def test_no_gap():
     line_markers[4] = LineType.blank_line
     line_markers[5] = LineType._assert  # assert result == 4
 
-    with pytest.raises(ValidationError) as excinfo:
-        line_markers.check_arrange_act_spacing()
+    result = line_markers.check_arrange_act_spacing()
 
-    assert excinfo.value.line_number == 7
-    assert excinfo.value.offset == 0
-    assert excinfo.value.text == 'AAA03 expected 1 blank line before Act block, found none'
+    assert isinstance(result, Generator)
+    errors = list(result)
+    assert len(errors) == 1
+    assert isinstance(errors[0], AAAError)
+    assert errors[0] == AAAError(
+        line_number=7,
+        offset=0,
+        text='AAA03 expected 1 blank line before Act block, found none',
+    )
 
 
 def test_too_big_gap():
@@ -79,9 +86,14 @@ def test_too_big_gap():
     line_markers[6] = LineType.blank_line
     line_markers[7] = LineType._assert  # assert result == 4
 
-    with pytest.raises(ValidationError) as excinfo:
-        line_markers.check_arrange_act_spacing()
+    result = line_markers.check_arrange_act_spacing()
 
-    assert excinfo.value.line_number == 8
-    assert excinfo.value.offset == 0
-    assert excinfo.value.text == 'AAA03 expected 1 blank line before Act block, found 2'
+    assert isinstance(result, Generator)
+    errors = list(result)
+    assert len(errors) == 1
+    assert isinstance(errors[0], AAAError)
+    assert errors[0] == AAAError(
+        line_number=8,
+        offset=0,
+        text='AAA03 expected 1 blank line before Act block, found 2',
+    )


### PR DESCRIPTION
Continued refactoring as a result of #76 :

* `Function.check_all()` does two things:

  - Tries to generate `AAAError` instances for every error that it finds in the test function.

  - Raises `ValidationError` if any of those errors are critical, this means that exceptions are only used in the case where processing can not continue.

* `Checker.run()` then:

  - Runs over those errors adding its class to the tuple and yields those up to Flake8.

  - If a `ValidationError` is received, then it converts that to a Flake8 error and yields it and halts.

* `do_command_line()` now just handles `AAAError` instances, it does not care about the class that raised the error. If it receives a `ValidationError` it converts that to `AAAError` and shows it.