### PR TITLE
Fix documentation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,11 @@ clean:
 	find . -name '*.pyc' -delete
 
 .PHONY: sdist
-sdist: clean tox
+sdist: tox
 	python setup.py sdist
 
 .PHONY: bdist_wheel
-bdist_wheel: clean tox
+bdist_wheel: tox
 	python setup.py bdist_wheel
 
 .PHONY: testpypi
@@ -94,7 +94,7 @@ testpypi: clean sdist bdist_wheel
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 .PHONY: pypi
-pypi: clean sdist bdist_wheel
+pypi: sdist bdist_wheel
 	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 .PHONY: on_master

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ that Flake8-AAA was installed correctly by asking ``flake8`` for its version
 signature::
 
     $ flake8 --version
-    3.7.7 (aaa: 0.6.0, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.6.7 on Linux
+    3.7.7 (aaa: 0.6.1, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.6.7 on Linux
 
 The ``aaa: 0.6.0`` part of that output tells you ``flake8`` found this
 plugin. Now you can run ``flake8`` as usual against your project and Flake8-AAA

--- a/docs/release_checklist.rst
+++ b/docs/release_checklist.rst
@@ -49,7 +49,7 @@ Given a new version called ``x.y.z``:
   broken before building)
 
 * After successful push, check the `TestPyPI page
-  <https://test.pypi.org/project/pysyncgateway/>`_.
+  <https://test.pypi.org/project/flake8-aaa/>`_.
 
 * Then tag the repo with ``make tag``. Add a short message about what the key
   change is.
@@ -59,7 +59,7 @@ Given a new version called ``x.y.z``:
 * Build and push to PyPI with ``make pypi``.
 
 * After successful push, check the `PyPI page
-  <https://pypi.org/project/pysyncgateway/>`_.
+  <https://pypi.org/project/flake8-aaa/>`_.
 
 Post release checks
 -------------------

--- a/docs/release_checklist.rst
+++ b/docs/release_checklist.rst
@@ -36,8 +36,8 @@ Given a new version called ``x.y.z``:
     updated using the output of the ``cmd`` and ``cmdbad`` ``tox``
     environments.
 
-  - Check the Flake8 signature output in the README. This can be updated using
-    the output of ``tox``.
+  - Update the Flake8 signature output in the README by running
+    ``./update_sig.sh``.
 
 * When branch ``bump-vx.y.z`` is green, then merge it to ``master``.
 

--- a/update_sig.sh
+++ b/update_sig.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo "Current:"
+grep -E "CPython" README.rst
+
+echo "Running tox to generate new line..."
+NEWLINE=$(tox -e py36-install | grep -E "CPython")
+
+echo "Updating file..."
+sed -i "s/.* CPython .* Linux/    $NEWLINE/" README.rst
+
+git diff -- README.rst


### PR DESCRIPTION
* Fix broken links in release checklist.

* Make it easier to update Flake8's signature after installing Flake8-aaa.

* Soften build script to not run `clean` recipe when doing `make pypi`.