### PR TITLE
Adjust offsets and line numbers on AAA03 and 04

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Unreleased_
 See also `latest documentation
 <https://flake8-aaa.readthedocs.io/en/latest/>`_.
 
+Changed
+.......
+
+* AAA03 and AAA04 (checks for a single blank line before and after Act block)
+  line numbers have been moved down. `Part of #79
+  <https://github.com/jamescooke/flake8-aaa/issues/79#issuecomment-495814091>`_.
+
+* AAA03 and AAA04 errors now return a real offset. `#79
+  <https://github.com/jamescooke/flake8-aaa/issues/79>`_.
+
 0.6.2_ - 2019/06/29
 -------------------
 

--- a/examples/bad/bad_expected.out
+++ b/examples/bad/bad_expected.out
@@ -1,8 +1,8 @@
 examples/bad/test_aaa01.py:8:1: AAA01 no Act block found in test
-examples/bad/test_aaa03_04.py:3:1: AAA03 expected 1 blank line before Act block, found none
-examples/bad/test_aaa03_04.py:4:1: AAA04 expected 1 blank line before Assert block, found none
-examples/bad/test_aaa03.py:3:1: AAA03 expected 1 blank line before Act block, found none
-examples/bad/test_aaa04.py:5:1: AAA04 expected 1 blank line before Assert block, found none
+examples/bad/test_aaa03_04.py:3:5: AAA03 expected 1 blank line before Act block, found none
+examples/bad/test_aaa03_04.py:4:5: AAA04 expected 1 blank line before Assert block, found none
+examples/bad/test_aaa03.py:3:5: AAA03 expected 1 blank line before Act block, found none
+examples/bad/test_aaa04.py:5:5: AAA04 expected 1 blank line before Assert block, found none
 examples/bad/test_aaa05.py:24:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:35:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:41:1: AAA05 blank line in block
@@ -10,4 +10,4 @@ examples/bad/test_aaa05.py:50:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:54:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:58:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:9:1: AAA05 blank line in block
-examples/bad/test_example.py:4:1: AAA03 expected 1 blank line before Act block, found none
+examples/bad/test_example.py:4:5: AAA03 expected 1 blank line before Act block, found none

--- a/examples/bad/bad_expected.out
+++ b/examples/bad/bad_expected.out
@@ -1,8 +1,8 @@
 examples/bad/test_aaa01.py:8:1: AAA01 no Act block found in test
-examples/bad/test_aaa03_04.py:2:1: AAA03 expected 1 blank line before Act block, found none
-examples/bad/test_aaa03_04.py:3:1: AAA04 expected 1 blank line before Assert block, found none
-examples/bad/test_aaa03.py:2:1: AAA03 expected 1 blank line before Act block, found none
-examples/bad/test_aaa04.py:4:1: AAA04 expected 1 blank line before Assert block, found none
+examples/bad/test_aaa03_04.py:3:1: AAA03 expected 1 blank line before Act block, found none
+examples/bad/test_aaa03_04.py:4:1: AAA04 expected 1 blank line before Assert block, found none
+examples/bad/test_aaa03.py:3:1: AAA03 expected 1 blank line before Act block, found none
+examples/bad/test_aaa04.py:5:1: AAA04 expected 1 blank line before Assert block, found none
 examples/bad/test_aaa05.py:24:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:35:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:41:1: AAA05 blank line in block
@@ -10,4 +10,4 @@ examples/bad/test_aaa05.py:50:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:54:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:58:1: AAA05 blank line in block
 examples/bad/test_aaa05.py:9:1: AAA05 blank line in block
-examples/bad/test_example.py:3:1: AAA03 expected 1 blank line before Act block, found none
+examples/bad/test_example.py:4:1: AAA03 expected 1 blank line before Act block, found none

--- a/examples/good/black/noqa/test_03.py
+++ b/examples/good/black/noqa/test_03.py
@@ -1,5 +1,5 @@
-def test():  # noqa
-    x = 1  # noqa
-    result = x + 1
+def test():
+    x = 1
+    result = x + 1  # noqa
 
     assert result == 2

--- a/examples/good/black/noqa/test_04.py
+++ b/examples/good/black/noqa/test_04.py
@@ -1,3 +1,3 @@
-def test():  # noqa
-    result = 1  # noqa
-    assert result == 1
+def test():
+    result = 1
+    assert result == 1  # noqa

--- a/examples/good/noqa/test_03.py
+++ b/examples/good/noqa/test_03.py
@@ -1,5 +1,5 @@
-def test():  # noqa
-    x = 1  # noqa
-    result = x + 1
+def test():
+    x = 1
+    result = x + 1  # noqa
 
     assert result == 2

--- a/examples/good/noqa/test_04.py
+++ b/examples/good/noqa/test_04.py
@@ -1,3 +1,3 @@
-def test():  # noqa
-    result = 1  # noqa
-    assert result == 1
+def test():
+    result = 1
+    assert result == 1  # noqa

--- a/src/flake8_aaa/function.py
+++ b/src/flake8_aaa/function.py
@@ -42,7 +42,7 @@ class Function:
         self.act_node = None  # type: Optional[ActNode]
         self.act_block = None  # type: Optional[Block]
         self.assert_block = None  # type: Optional[Block]
-        self.line_markers = LineMarkers(len(self.lines), self.first_line_no)  # type: LineMarkers
+        self.line_markers = LineMarkers(self.lines, self.first_line_no)  # type: LineMarkers
 
     def __str__(self, errors: Optional[List[AAAError]] = None) -> str:
         out = '------+------------------------------------------------------------------------\n'

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -26,6 +26,25 @@ def is_test_file(filename: str) -> bool:
     return os.path.basename(filename).startswith('test_')
 
 
+def first_non_blank_char(line: str) -> int:
+    """
+    Examples:
+        1.  Empty string has no non-blank chars.
+        >>> first_non_blank_char('')
+        0
+
+        2.  First char after whitespace or tabs works.
+        >>> first_non_blank_char('    return')
+        4
+        >>> first_non_blank_char('        return')
+        8
+    """
+    for pos, char in enumerate(line):
+        if not char.isspace():
+            return pos
+    return 0
+
+
 class TestFuncLister(ast.NodeVisitor):
     """
     Helper to walk the ast Tree and find functions that looks like tests.

--- a/src/flake8_aaa/line_markers.py
+++ b/src/flake8_aaa/line_markers.py
@@ -10,8 +10,9 @@ class LineMarkers(list):
     line.
     """
 
-    def __init__(self, size: int, fn_offset: int) -> None:
-        super().__init__([LineType.unprocessed] * size)
+    def __init__(self, lines: typing.List[str], fn_offset: int) -> None:
+        super().__init__([LineType.unprocessed] * len(lines))
+        self.lines = lines  # type: typing.List[str]
         self.fn_offset = fn_offset  # type: int
 
     @typing.overload  # noqa: F811

--- a/src/flake8_aaa/line_markers.py
+++ b/src/flake8_aaa/line_markers.py
@@ -123,22 +123,14 @@ class LineMarkers(list):
             bl for bl in numbered_lines[first_block_lineno + 1:second_block_lineno] if bl[1] is LineType.blank_line
         ]
 
-        if not blank_lines:
-            # Point at line above second block
+        if not blank_lines or len(blank_lines) != 1:
+            # Point at first line of second block
             yield AAAError(
-                line_number=self.fn_offset + second_block_lineno - 1,
+                line_number=self.fn_offset + second_block_lineno,
                 offset=0,
-                text=error_message.format('none'),
+                text=error_message.format('none' if not blank_lines else len(blank_lines)),
             )
             return
-
-        if len(blank_lines) > 1:
-            # Too many blank lines - point at the first extra one, the 2nd
-            yield AAAError(
-                line_number=self.fn_offset + blank_lines[1][0],
-                offset=0,
-                text=error_message.format(len(blank_lines)),
-            )
 
     def check_blank_lines(self) -> typing.Generator[AAAError, None, None]:
         checked_blocks = (LineType.func_def, LineType.arrange, LineType.act, LineType._assert)

--- a/tests/function/test_check_all.py
+++ b/tests/function/test_check_all.py
@@ -74,7 +74,7 @@ def test_missing_space_before_act(function):
     errors = list(result)
     assert len(errors) == 1
     assert isinstance(errors[0], AAAError)
-    assert errors[0].line_number == 3
+    assert errors[0].line_number == 4
     assert errors[0].offset == 0
     assert errors[0].text == 'AAA03 expected 1 blank line before Act block, found none'
 
@@ -105,7 +105,7 @@ def test_missing_space_before_assert(function):
     assert isinstance(result, Generator)
     errors = list(result)
     assert len(errors) == 1
-    assert errors[0].line_number == 5
+    assert errors[0].line_number == 6
     assert errors[0].offset == 0
     assert errors[0].text == 'AAA04 expected 1 blank line before Assert block, found none'
 

--- a/tests/function/test_check_all.py
+++ b/tests/function/test_check_all.py
@@ -75,7 +75,7 @@ def test_missing_space_before_act(function):
     assert len(errors) == 1
     assert isinstance(errors[0], AAAError)
     assert errors[0].line_number == 4
-    assert errors[0].offset == 0
+    assert errors[0].offset == 4
     assert errors[0].text == 'AAA03 expected 1 blank line before Act block, found none'
 
 
@@ -106,7 +106,7 @@ def test_missing_space_before_assert(function):
     errors = list(result)
     assert len(errors) == 1
     assert errors[0].line_number == 6
-    assert errors[0].offset == 0
+    assert errors[0].offset == 4
     assert errors[0].text == 'AAA04 expected 1 blank line before Assert block, found none'
 
 

--- a/tests/function/test_str.py
+++ b/tests/function/test_str.py
@@ -93,7 +93,7 @@ def test_processed(function):
  2 DEF|def test(file_resource):
  3 ARR|    file_resource.connect()
  4 ACT|    result = file_resource.retrieve()
-       ^ AAA03 expected 1 blank line before Act block, found none
+           ^ AAA03 expected 1 blank line before Act block, found none
  5 BL |
  6 ASS|    assert result.success is True
 ------+------------------------------------------------------------------------
@@ -126,7 +126,7 @@ def test_multi_spaces(function):
  5 BL |
  6 BL |
  7 ACT|    result = x + y
-       ^ AAA03 expected 1 blank line before Act block, found 2
+           ^ AAA03 expected 1 blank line before Act block, found 2
  8 BL |
  9 ASS|    assert result == 2
 ------+------------------------------------------------------------------------
@@ -150,9 +150,9 @@ def test_multi_errors(function):
  2 DEF|def test():
  3 ARR|    x = 1
  4 ACT|    result = x * 5
-       ^ AAA03 expected 1 blank line before Act block, found none
+           ^ AAA03 expected 1 blank line before Act block, found none
  5 ASS|    assert result == 5
-       ^ AAA04 expected 1 blank line before Assert block, found none
+           ^ AAA04 expected 1 blank line before Assert block, found none
 ------+------------------------------------------------------------------------
     2 | ERRORS
 '''.lstrip()

--- a/tests/function/test_str.py
+++ b/tests/function/test_str.py
@@ -92,8 +92,8 @@ def test_processed(function):
 ------+------------------------------------------------------------------------
  2 DEF|def test(file_resource):
  3 ARR|    file_resource.connect()
-       ^ AAA03 expected 1 blank line before Act block, found none
  4 ACT|    result = file_resource.retrieve()
+       ^ AAA03 expected 1 blank line before Act block, found none
  5 BL |
  6 ASS|    assert result.success is True
 ------+------------------------------------------------------------------------
@@ -125,8 +125,8 @@ def test_multi_spaces(function):
  4 ARR|    y = 1
  5 BL |
  6 BL |
-       ^ AAA03 expected 1 blank line before Act block, found 2
  7 ACT|    result = x + y
+       ^ AAA03 expected 1 blank line before Act block, found 2
  8 BL |
  9 ASS|    assert result == 2
 ------+------------------------------------------------------------------------
@@ -149,10 +149,10 @@ def test_multi_errors(function):
 ------+------------------------------------------------------------------------
  2 DEF|def test():
  3 ARR|    x = 1
-       ^ AAA03 expected 1 blank line before Act block, found none
  4 ACT|    result = x * 5
-       ^ AAA04 expected 1 blank line before Assert block, found none
+       ^ AAA03 expected 1 blank line before Act block, found none
  5 ASS|    assert result == 5
+       ^ AAA04 expected 1 blank line before Assert block, found none
 ------+------------------------------------------------------------------------
     2 | ERRORS
 '''.lstrip()

--- a/tests/line_markers/test_check_act_assert_spacing.py
+++ b/tests/line_markers/test_check_act_assert_spacing.py
@@ -9,7 +9,7 @@ def test_comment_before_assert():
     """
     Comment before Assert passes
     """
-    line_markers = LineMarkers(8, 5)
+    line_markers = LineMarkers(8 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange  # x = 1
     line_markers[2] = LineType.arrange  # y = 2
@@ -26,7 +26,7 @@ def test_comment_before_assert():
 
 
 def test_none():
-    line_markers = LineMarkers(2, 0)
+    line_markers = LineMarkers(2 * [''], 0)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.act  # do_thing()
 
@@ -43,7 +43,7 @@ def test_no_gap():
     """
     No gap raises - error points at act block because no spaces
     """
-    line_markers = LineMarkers(6, 5)
+    line_markers = LineMarkers(6 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange  # x = 1
     line_markers[2] = LineType.blank_line
@@ -67,7 +67,7 @@ def test_too_big_gap():
     """
     Multiple BL raises. First extra line is pointed to
     """
-    line_markers = LineMarkers(8, 5)
+    line_markers = LineMarkers(8 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange  # x = 1
     line_markers[2] = LineType.blank_line

--- a/tests/line_markers/test_check_act_assert_spacing.py
+++ b/tests/line_markers/test_check_act_assert_spacing.py
@@ -56,7 +56,7 @@ def test_no_gap():
     assert isinstance(result, Generator)
     assert list(result) == [
         AAAError(
-            line_number=9,
+            line_number=10,
             offset=0,
             text='AAA04 expected 1 blank line before Assert block, found none',
         ),
@@ -82,7 +82,7 @@ def test_too_big_gap():
     assert isinstance(result, Generator)
     assert list(result) == [
         AAAError(
-            line_number=11,
+            line_number=12,
             offset=0,
             text='AAA04 expected 1 blank line before Assert block, found 2',
         ),

--- a/tests/line_markers/test_check_arrange_act_spacing.py
+++ b/tests/line_markers/test_check_arrange_act_spacing.py
@@ -9,7 +9,7 @@ def test_comment_before_act():
     """
     Comment before Act passes
     """
-    line_markers = LineMarkers(8, 5)
+    line_markers = LineMarkers(8 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange  # x = 1
     line_markers[2] = LineType.arrange  # y = 2
@@ -29,7 +29,7 @@ def test_no_arrange():
     """
     Tests without arrangement pass
     """
-    line_markers = LineMarkers(7, 5)
+    line_markers = LineMarkers(7 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.unprocessed  # Some docstring
     line_markers[2] = LineType.unprocessed  # Some docstring
@@ -51,7 +51,7 @@ def test_no_gap():
     """
     No gap raises - error points at act block
     """
-    line_markers = LineMarkers(6, 5)
+    line_markers = LineMarkers(6 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange  # x = 1
     line_markers[2] = LineType.unprocessed  # Sum do stuff
@@ -75,7 +75,7 @@ def test_too_big_gap():
     """
     Multiple BL raises. Act block is pointed to.
     """
-    line_markers = LineMarkers(8, 5)
+    line_markers = LineMarkers(8 * [''], 5)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange  # x = 1
     line_markers[2] = LineType.blank_line

--- a/tests/line_markers/test_check_arrange_act_spacing.py
+++ b/tests/line_markers/test_check_arrange_act_spacing.py
@@ -49,7 +49,7 @@ def test_no_arrange():
 
 def test_no_gap():
     """
-    No gap raises - error points at act block because no spaces
+    No gap raises - error points at act block
     """
     line_markers = LineMarkers(6, 5)
     line_markers[0] = LineType.func_def
@@ -62,18 +62,18 @@ def test_no_gap():
     result = line_markers.check_arrange_act_spacing()
 
     assert isinstance(result, Generator)
-    assert list(result) == [
-        AAAError(
-            line_number=7,
-            offset=0,
-            text='AAA03 expected 1 blank line before Act block, found none',
-        ),
-    ]
+    result_list = list(result)
+    assert len(result_list) == 1
+    assert result_list[0] == AAAError(
+        line_number=8,
+        offset=0,
+        text='AAA03 expected 1 blank line before Act block, found none',
+    )
 
 
 def test_too_big_gap():
     """
-    Multiple BL raises. First extra line is pointed to
+    Multiple BL raises. Act block is pointed to.
     """
     line_markers = LineMarkers(8, 5)
     line_markers[0] = LineType.func_def
@@ -88,10 +88,10 @@ def test_too_big_gap():
     result = line_markers.check_arrange_act_spacing()
 
     assert isinstance(result, Generator)
-    assert list(result) == [
-        AAAError(
-            line_number=8,
-            offset=0,
-            text='AAA03 expected 1 blank line before Act block, found 2',
-        ),
-    ]
+    result_list = list(result)
+    assert len(result_list) == 1
+    assert result_list[0] == AAAError(
+        line_number=10,
+        offset=0,
+        text='AAA03 expected 1 blank line before Act block, found 2',
+    )

--- a/tests/line_markers/test_check_blank_lines.py
+++ b/tests/line_markers/test_check_blank_lines.py
@@ -6,7 +6,7 @@ from flake8_aaa.types import LineType
 
 
 def test_ok():
-    line_markers = LineMarkers(6, 7)
+    line_markers = LineMarkers(6 * [''], 7)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange
     line_markers[2] = LineType.blank_line
@@ -24,7 +24,7 @@ def test_ok():
 
 
 def test_arrange():
-    line_markers = LineMarkers(8, 7)
+    line_markers = LineMarkers(8 * [''], 7)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.arrange
     line_markers[2] = LineType.blank_line
@@ -50,7 +50,7 @@ def test_func_def():
     """
     Function definition has some funky call args separated by a blank line
     """
-    line_markers = LineMarkers(3, 7)
+    line_markers = LineMarkers(3 * [''], 7)
     line_markers[0] = LineType.func_def
     line_markers[1] = LineType.blank_line
     line_markers[2] = LineType.func_def

--- a/tests/line_markers/test_init.py
+++ b/tests/line_markers/test_init.py
@@ -3,7 +3,7 @@ from flake8_aaa.types import LineType
 
 
 def test():
-    result = LineMarkers(5, 7)
+    result = LineMarkers(5 * [''], 7)
 
     assert result == [
         LineType.unprocessed,
@@ -12,4 +12,5 @@ def test():
         LineType.unprocessed,
         LineType.unprocessed,
     ]
+    assert result.lines == ['', '', '', '', '']
     assert result.fn_offset == 7

--- a/tests/line_markers/test_setitem.py
+++ b/tests/line_markers/test_setitem.py
@@ -5,7 +5,7 @@ from flake8_aaa.types import LineType
 
 
 def test():
-    line_markers = LineMarkers(2, 1)
+    line_markers = LineMarkers(2 * [''], 1)
 
     result = line_markers.__setitem__(0, LineType.func_def)
 
@@ -20,7 +20,7 @@ def test():
 
 
 def test_reassign():
-    line_markers = LineMarkers(2, 1)
+    line_markers = LineMarkers(2 * [''], 1)
     line_markers[0] = LineType.func_def
 
     with pytest.raises(ValueError) as excinfo:
@@ -30,14 +30,14 @@ def test_reassign():
 
 
 def test_out_of_range():
-    line_markers = LineMarkers(2, 1)
+    line_markers = LineMarkers(2 * [''], 1)
 
     with pytest.raises(IndexError):
         line_markers[10] = LineType.func_def
 
 
 def test_not_line_type():
-    line_markers = LineMarkers(2, 1)
+    line_markers = LineMarkers(2 * [''], 1)
 
     with pytest.raises(ValueError) as excinfo:
         line_markers[0] = 1
@@ -46,7 +46,7 @@ def test_not_line_type():
 
 
 def test_not_slice():
-    line_markers = LineMarkers(2, 1)
+    line_markers = LineMarkers(2 * [''], 1)
 
     with pytest.raises(NotImplementedError):
         line_markers[:] = LineType.act

--- a/tests/line_markers/test_update.py
+++ b/tests/line_markers/test_update.py
@@ -6,7 +6,7 @@ from flake8_aaa.types import LineType
 
 
 def test():
-    line_markers = LineMarkers(6, 1)
+    line_markers = LineMarkers(6 * [''], 1)
     line_markers[2] = LineType.blank_line
 
     result = line_markers.update((1, 3), LineType.act)
@@ -34,7 +34,7 @@ def test_collision():
         LineType.unprocessed,
     ]
     """
-    line_markers = LineMarkers(4, 10)
+    line_markers = LineMarkers(4 * [''], 10)
     line_markers[0] = LineType.func_def
     line_markers[2] = LineType.blank_line
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@
 #       Run pytest on test suite.
 
 [tox]
-envlist = py3{5,6,7}-{install,lint,test,cmd,cmdbad},py3{6,7}-lintexamples,py36-doc
+envlist = py3{5,6,7}-{install,lint,test,doctest,cmd,cmdbad},py3{6,7}-lintexamples,py36-doc
 
 [install]
 commands =
@@ -36,13 +36,16 @@ commands =
 
 [testenv]
 deps =
-    doc,lint,test: -rrequirements/test.txt
+    doc,doctest,lint,test: -rrequirements/test.txt
     lintexamples: -rrequirements/lintexamples.txt
     install: flake8>=3
+changedir =
+    doctest: src/flake8_aaa
 commands =
     cmd: make cmd
     cmdbad: make cmdbad
     doc: make doc
+    doctest: pytest
     install: {[install]commands}
     py3{6,7}-install: flake8 tests examples/good_py36_plus
     lint: make lint


### PR DESCRIPTION
Fixes #79 

Also:

* Turns on tests for docstrings.
* Extends `LineMarkers` to carry the lines of the test function so that offsets can be calculated for layout errors in the future.
