### PR TITLE
Bump requirements, flatten requirements using constraints `-c`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ venv/bin/pip-sync: venv
 
 .PHONY: dev
 dev: venv venv/bin/pip-sync
-	venv/bin/pip-sync requirements/dev.txt
+	venv/bin/pip-sync requirements/base.txt requirements/dev.txt
 
 .PHONY: tox
 tox:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ venv/bin/pip-sync: venv
 
 .PHONY: dev
 dev: venv venv/bin/pip-sync
-	venv/bin/pip-sync requirements/base.txt requirements/dev.txt
+	venv/bin/pip-sync requirements/base.txt requirements/test.txt requirements/dev.txt
 
 .PHONY: tox
 tox:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
-asttokens==1.1.13
+asttokens==1.1.14
 entrypoints==0.3          # via flake8
 flake8==3.7.8
 mccabe==0.6.1             # via flake8

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,4 @@
--r test.txt
+-c test.txt
 
 pip-tools
 twine

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,4 @@
+-c base.txt
 -c test.txt
 
 pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,21 +5,21 @@
 #    pip-compile --output-file=dev.txt dev.in
 #
 bleach==3.1.0             # via readme-renderer
-certifi==2019.6.16        # via requests
+certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 docutils==0.15.2          # via readme-renderer
 idna==2.8                 # via requests
-pip-tools==4.0.0
+pip-tools==4.1.0
 pkginfo==1.5.0.1          # via twine
 pygments==2.4.2           # via readme-renderer
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0          # via requests-toolbelt, twine
 six==1.12.0               # via bleach, pip-tools, readme-renderer
-tqdm==4.32.2              # via twine
-twine==1.13.0
-urllib3==1.25.3           # via requests
+tqdm==4.36.1              # via twine
+twine==1.15.0
+urllib3==1.25.5           # via requests
 webencodings==0.5.1       # via bleach
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,70 +4,23 @@
 #
 #    pip-compile --output-file=dev.txt dev.in
 #
-alabaster==0.7.12
-astroid==2.2.5
-asttokens==1.1.13
-atomicwrites==1.3.0
-attrs==19.1.0
-babel==2.7.0
 bleach==3.1.0             # via readme-renderer
-certifi==2019.6.16
-chardet==3.0.4
+certifi==2019.6.16        # via requests
+chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
-docutils==0.15.2
-entrypoints==0.3
-filelock==3.0.12
-flake8==3.7.8
-idna==2.8
-imagesize==1.1.0
-importlib-metadata==0.19
-isort==4.3.21
-jinja2==2.10.1
-lazy-object-proxy==1.4.1
-markupsafe==1.1.1
-mccabe==0.6.1
-more-itertools==7.2.0
-mypy-extensions==0.4.1
-mypy==0.720
-packaging==19.1
+docutils==0.15.2          # via readme-renderer
+idna==2.8                 # via requests
 pip-tools==4.0.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.12.0
-py==1.8.0
-pycodestyle==2.5.0
-pyflakes==2.1.1
-pygments==2.4.2
-pylint==2.3.1
-pyparsing==2.4.2
-pytest==5.0.1
-pytz==2019.2
+pygments==2.4.2           # via readme-renderer
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.22.0
-restructuredtext-lint==1.3.0
-six==1.12.0
-snowballstemmer==1.9.0
-sphinx-rtd-theme==0.4.3
-sphinx==2.1.2
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
-toml==0.10.0
-tox==3.13.2
+requests==2.22.0          # via requests-toolbelt, twine
+six==1.12.0               # via bleach, pip-tools, readme-renderer
 tqdm==4.32.2              # via twine
 twine==1.13.0
-typed-ast==1.4.0
-typing-extensions==3.7.4
-urllib3==1.25.3
-virtualenv==16.7.2
-wcwidth==0.1.7
+urllib3==1.25.3           # via requests
 webencodings==0.5.1       # via bleach
-wrapt==1.11.2
-yapf==0.28.0
-zipp==0.5.2
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via sphinx, twine
+# setuptools==41.2.0        # via twine

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,23 +14,23 @@ bleach==3.1.0             # via readme-renderer
 certifi==2019.6.16
 chardet==3.0.4
 click==7.0                # via pip-tools
-docutils==0.14
+docutils==0.15.2
 entrypoints==0.3
 filelock==3.0.12
 flake8==3.7.8
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.18
+importlib-metadata==0.19
 isort==4.3.21
 jinja2==2.10.1
 lazy-object-proxy==1.4.1
 markupsafe==1.1.1
 mccabe==0.6.1
-more-itertools==7.1.0
+more-itertools==7.2.0
 mypy-extensions==0.4.1
 mypy==0.720
-packaging==19.0
-pip-tools==3.8.0
+packaging==19.1
+pip-tools==4.0.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.12.0
 py==1.8.0
@@ -38,9 +38,9 @@ pycodestyle==2.5.0
 pyflakes==2.1.1
 pygments==2.4.2
 pylint==2.3.1
-pyparsing==2.4.0
+pyparsing==2.4.2
 pytest==5.0.1
-pytz==2019.1
+pytz==2019.2
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0
@@ -62,7 +62,7 @@ twine==1.13.0
 typed-ast==1.4.0
 typing-extensions==3.7.4
 urllib3==1.25.3
-virtualenv==16.6.1
+virtualenv==16.7.2
 wcwidth==0.1.7
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,4 @@
--r base.txt
+-c base.txt
 
 Sphinx
 flake8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,14 +6,13 @@
 #
 alabaster==0.7.12         # via sphinx
 astroid==2.2.5            # via pylint
-asttokens==1.1.13
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via packaging, pytest
 babel==2.7.0              # via sphinx
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 docutils==0.15.2          # via restructuredtext-lint, sphinx
-entrypoints==0.3
+entrypoints==0.3          # via flake8
 filelock==3.0.12          # via tox
 flake8==3.7.8
 idna==2.8                 # via requests
@@ -23,15 +22,15 @@ isort==4.3.21
 jinja2==2.10.1            # via sphinx
 lazy-object-proxy==1.4.1  # via astroid
 markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1
+mccabe==0.6.1             # via flake8, pylint
 more-itertools==7.2.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.720
 packaging==19.1           # via pytest, sphinx, tox
 pluggy==0.12.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
-pycodestyle==2.5.0
-pyflakes==2.1.1
+pycodestyle==2.5.0        # via flake8
+pyflakes==2.1.1           # via flake8
 pygments==2.4.2
 pylint==2.3.1
 pyparsing==2.4.2          # via packaging
@@ -61,4 +60,4 @@ yapf==0.28.0
 zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via sphinx
+# setuptools==41.2.0        # via sphinx

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,35 +8,35 @@ alabaster==0.7.12         # via sphinx
 astroid==2.2.5            # via pylint
 asttokens==1.1.13
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==19.1.0             # via packaging, pytest
 babel==2.7.0              # via sphinx
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
-docutils==0.14            # via restructuredtext-lint, sphinx
+docutils==0.15.2          # via restructuredtext-lint, sphinx
 entrypoints==0.3
 filelock==3.0.12          # via tox
 flake8==3.7.8
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.18  # via pluggy, pytest, tox
+importlib-metadata==0.19  # via pluggy, pytest, tox
 isort==4.3.21
 jinja2==2.10.1            # via sphinx
 lazy-object-proxy==1.4.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1
-more-itertools==7.1.0     # via pytest
+more-itertools==7.2.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.720
-packaging==19.0           # via pytest, sphinx, tox
+packaging==19.1           # via pytest, sphinx, tox
 pluggy==0.12.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pygments==2.4.2
 pylint==2.3.1
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.2          # via packaging
 pytest==5.0.1
-pytz==2019.1              # via babel
+pytz==2019.2              # via babel
 requests==2.22.0          # via sphinx
 restructuredtext-lint==1.3.0
 six==1.12.0
@@ -54,7 +54,7 @@ tox==3.13.2
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via mypy
 urllib3==1.25.3           # via requests
-virtualenv==16.6.1        # via tox
+virtualenv==16.7.2        # via tox
 wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid
 yapf==0.28.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,9 +7,9 @@
 alabaster==0.7.12         # via sphinx
 astroid==2.2.5            # via pylint
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via packaging, pytest
+attrs==19.1.0             # via pytest
 babel==2.7.0              # via sphinx
-certifi==2019.6.16        # via requests
+certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 docutils==0.15.2          # via restructuredtext-lint, sphinx
 entrypoints==0.3          # via flake8
@@ -17,31 +17,31 @@ filelock==3.0.12          # via tox
 flake8==3.7.8
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.19  # via pluggy, pytest, tox
+importlib-metadata==0.23  # via pluggy, pytest, tox
 isort==4.3.21
 jinja2==2.10.1            # via sphinx
-lazy-object-proxy==1.4.1  # via astroid
+lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8, pylint
-more-itertools==7.2.0     # via pytest
+more-itertools==7.2.0     # via pytest, zipp
 mypy-extensions==0.4.1    # via mypy
 mypy==0.720
-packaging==19.1           # via pytest, sphinx, tox
-pluggy==0.12.0            # via pytest, tox
+packaging==19.2           # via pytest, sphinx, tox
+pluggy==0.13.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2
 pylint==2.3.1
 pyparsing==2.4.2          # via packaging
-pytest==5.0.1
+pytest==5.1.3
 pytz==2019.2              # via babel
 requests==2.22.0          # via sphinx
 restructuredtext-lint==1.3.0
 six==1.12.0
-snowballstemmer==1.9.0    # via sphinx
+snowballstemmer==1.9.1    # via sphinx
 sphinx-rtd-theme==0.4.3
-sphinx==2.1.2
+sphinx==2.2.0
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
@@ -49,15 +49,15 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 toml==0.10.0              # via tox
-tox==3.13.2
+tox==3.14.0
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via mypy
-urllib3==1.25.3           # via requests
-virtualenv==16.7.2        # via tox
+urllib3==1.25.5           # via requests
+virtualenv==16.7.5        # via tox
 wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid
 yapf==0.28.0
-zipp==0.5.2               # via importlib-metadata
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.2.0        # via sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
 
 [testenv]
 deps =
+    doc,doctest,lint,test: -rrequirements/base.txt
     doc,doctest,lint,test: -rrequirements/test.txt
     lintexamples: -rrequirements/lintexamples.txt
     install: flake8>=3


### PR DESCRIPTION
* Uses `-c` instead of `-r` in pip-tools's `.in` files. This gives the same constraints as `-r` but without polluting the built `*.txt` requirements files. See https://github.com/jazzband/pip-tools/issues/398#issuecomment-517972391

* Adjusts installs to install all layers required.

TODO:

- [x] Fix `make dev` - is missing `test.txt`
- [x] Rebump packages.

