### PR TITLE
Bump all requirements, includes asttokens v2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
-asttokens==1.1.14
+asttokens==2.0.1
 entrypoints==0.3          # via flake8
 flake8==3.7.8
 mccabe==0.6.1             # via flake8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 docutils==0.15.2          # via readme-renderer
 idna==2.8                 # via requests
-pip-tools==4.1.0
+pip-tools==4.2.0
 pkginfo==1.5.0.1          # via twine
 pygments==2.4.2           # via readme-renderer
 readme-renderer==24.0     # via twine
@@ -18,9 +18,9 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.22.0          # via requests-toolbelt, twine
 six==1.12.0               # via bleach, pip-tools, readme-renderer
 tqdm==4.36.1              # via twine
-twine==1.15.0
-urllib3==1.25.5           # via requests
+twine==2.0.0
+urllib3==1.25.6           # via requests
 webencodings==0.5.1       # via bleach
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via twine
+# setuptools==41.4.0        # via twine

--- a/requirements/lintexamples.txt
+++ b/requirements/lintexamples.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=lintexamples.txt lintexamples.in
 #
 appdirs==1.4.3            # via black
-attrs==19.1.0             # via black
+attrs==19.3.0             # via black
 black==19.3b0
 click==7.0                # via black
 entrypoints==0.3          # via flake8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,9 +5,9 @@
 #    pip-compile --output-file=test.txt test.in
 #
 alabaster==0.7.12         # via sphinx
-astroid==2.2.5            # via pylint
+astroid==2.3.2            # via pylint
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==19.3.0             # via pytest
 babel==2.7.0              # via sphinx
 certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
@@ -19,27 +19,27 @@ idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 importlib-metadata==0.23  # via pluggy, pytest, tox
 isort==4.3.21
-jinja2==2.10.1            # via sphinx
+jinja2==2.10.3            # via sphinx
 lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8, pylint
 more-itertools==7.2.0     # via pytest, zipp
-mypy-extensions==0.4.1    # via mypy
-mypy==0.720
+mypy-extensions==0.4.3    # via mypy
+mypy==0.740
 packaging==19.2           # via pytest, sphinx, tox
 pluggy==0.13.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2
-pylint==2.3.1
+pylint==2.4.3
 pyparsing==2.4.2          # via packaging
-pytest==5.1.3
-pytz==2019.2              # via babel
+pytest==5.2.1
+pytz==2019.3              # via babel
 requests==2.22.0          # via sphinx
 restructuredtext-lint==1.3.0
 six==1.12.0
-snowballstemmer==1.9.1    # via sphinx
+snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==2.2.0
 sphinxcontrib-applehelp==1.0.1  # via sphinx
@@ -52,12 +52,12 @@ toml==0.10.0              # via tox
 tox==3.14.0
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via mypy
-urllib3==1.25.5           # via requests
-virtualenv==16.7.5        # via tox
+urllib3==1.25.6           # via requests
+virtualenv==16.7.7        # via tox
 wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid
 yapf==0.28.0
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via sphinx
+# setuptools==41.4.0        # via sphinx


### PR DESCRIPTION
All tests pass when using asttokens v2 (https://github.com/gristlabs/asttokens/releases/tag/v2.0.0) - which is good news.