### PR TITLE
Fix annotated assignment Act block search

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Unreleased_
 See also `latest documentation
 <https://flake8-aaa.readthedocs.io/en/latest/>`_.
 
+Fixed
+.....
+
+* NEEDS CONFIRMATION: Bug preventing type annotated assignment Act blocks from being found `#123
+  <https://github.com/jamescooke/flake8-aaa/pull/123>`_
+
 0.7.1_ - 2019/11/16
 -------------------
 

--- a/examples/good/test_type_hints.py
+++ b/examples/good/test_type_hints.py
@@ -1,0 +1,17 @@
+def add_one(x: int) -> int:
+    return x + 1
+
+
+# Example from https://github.com/jamescooke/flake8-aaa/issues/122
+
+
+def test_add_one() -> None:
+    # Arrange.
+    data: int = 0
+
+    # Act.
+    result: int = add_one(data)
+
+    # Assert.
+    assert result != data
+    assert result == data + 1

--- a/examples/good_py36_plus/test_type_hints.py
+++ b/examples/good_py36_plus/test_type_hints.py
@@ -6,6 +6,9 @@ def add_one(x: int) -> int:
 
 
 def test_add_one() -> None:
+    """
+    Addition of type hint in act block does not prevent act block being found
+    """
     # Arrange.
     data: int = 0
 

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -93,11 +93,11 @@ def node_is_result_assignment(node: ast.AST) -> bool:
 
     # py35 has no Annotated Assignment, so work around it...
     try:
-        AnnAssign = getattr(ast, 'AnnAssign')
+        ann_assign_cls = getattr(ast, 'AnnAssign')
     except AttributeError:
         return False
 
-    if isinstance(node, AnnAssign):
+    if isinstance(node, ann_assign_cls):
         return node.target.id == "result"  # type: ignore
     return False
 

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -87,14 +87,11 @@ def node_is_result_assignment(node: ast.AST) -> bool:
     Returns:
         bool: ``node`` corresponds to the code ``result =``, assignment to the
         ``result `` variable.
-
-    Note:
-        Performs a very weak test that the line starts with 'result =' rather
-        than testing the tokens.
     """
-    # `.first_token` is added by asttokens
-    token = node.first_token  # type: ignore
-    return token.line.strip().startswith('result =')
+    return (
+        isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "result"
+    ) or (isinstance(node, ast.AnnAssign) and node.target.id == "result")
 
 
 def node_is_pytest_raises(node: ast.AST) -> bool:

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -88,10 +88,11 @@ def node_is_result_assignment(node: ast.AST) -> bool:
         bool: ``node`` corresponds to the code ``result =``, assignment to the
         ``result `` variable.
     """
-    return (
-        isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)
-        and node.targets[0].id == "result"
-    ) or (isinstance(node, ast.AnnAssign) and node.target.id == "result")
+    if isinstance(node, ast.Assign):
+        return len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and node.targets[0].id == "result"
+    if isinstance(node, ast.AnnAssign):
+        return node.target.id == "result"  # type: ignore
+    return False
 
 
 def node_is_pytest_raises(node: ast.AST) -> bool:

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -90,7 +90,14 @@ def node_is_result_assignment(node: ast.AST) -> bool:
     """
     if isinstance(node, ast.Assign):
         return len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and node.targets[0].id == "result"
-    if isinstance(node, ast.AnnAssign):
+
+    # py35 has no Annotated Assignment, so work around it...
+    try:
+        AnnAssign = ast.AnnAssign
+    except AttributeError:
+        return False
+
+    if isinstance(node, AnnAssign):
         return node.target.id == "result"  # type: ignore
     return False
 

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -93,7 +93,7 @@ def node_is_result_assignment(node: ast.AST) -> bool:
 
     # py35 has no Annotated Assignment, so work around it...
     try:
-        AnnAssign = ast.AnnAssign
+        AnnAssign = getattr(ast, 'AnnAssign')
     except AttributeError:
         return False
 

--- a/tests_py36_plus/act_node/test_build.py
+++ b/tests_py36_plus/act_node/test_build.py
@@ -1,0 +1,23 @@
+import pytest
+
+from flake8_aaa.act_node import ActNode
+from flake8_aaa.types import ActNodeType
+
+
+@pytest.mark.parametrize(
+    'code_str, expected_type', [
+        ('result: Thing = do_thing()', ActNodeType.result_assignment),
+        ('result: List[int] = do_thing()', ActNodeType.result_assignment),
+    ]
+)
+def test(expected_type, first_node_with_tokens):
+    """
+    Assert that type-hinted result assignments can be found as act blocks
+    """
+    result: ActNode = ActNode.build(first_node_with_tokens)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], ActNode)
+    assert result[0].node == first_node_with_tokens
+    assert result[0].block_type == expected_type

--- a/tests_py36_plus/helpers/test_node_is_result_assignment.py
+++ b/tests_py36_plus/helpers/test_node_is_result_assignment.py
@@ -1,0 +1,17 @@
+import pytest
+
+from flake8_aaa.helpers import node_is_result_assignment
+
+
+@pytest.mark.parametrize(
+    ('code_str', 'expected_result'),
+    [
+        ('result: int = 1', True),
+        ('result: List[int] = [1]', True),
+        ('xresult: int = 1', False),
+    ],
+)
+def test_no(first_node_with_tokens, expected_result):
+    result = node_is_result_assignment(first_node_with_tokens)
+
+    assert result is expected_result


### PR DESCRIPTION
As per #122 , annotated assignment act blocks were not found: `result: int = add(x, y)`.

This PR adjusts the Act node search to inspect the AST, rather than just look for `result =` at the start of the line.