### PR TITLE
Use NodeVisitor to find "stringy" lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Unreleased_
 See also `latest documentation
 <https://flake8-aaa.readthedocs.io/en/latest/>`_.
 
+Changed
+.......
+
+* Line that are covered by strings (like docstrings) are found with a
+  ``NodeVisitor``. Previously this was an iterator on the tree. `#132
+  <https://github.com/jamescooke/flake8-aaa/pull/132>`_.
+
 0.8.0_ - 2020/02/27
 -------------------
 

--- a/src/flake8_aaa/act_node.py
+++ b/src/flake8_aaa/act_node.py
@@ -1,7 +1,7 @@
 import ast
 from typing import List, Type, TypeVar
 
-from .helpers import node_is_pytest_raises, node_is_result_assignment, node_is_unittest_raises
+from .helpers import get_first_token, node_is_pytest_raises, node_is_result_assignment, node_is_unittest_raises
 from .types import ActNodeType
 
 AN = TypeVar('AN', bound='ActNode')  # Place holder for ActNode instances
@@ -20,8 +20,8 @@ class ActNode:
             node
             block_type
         """
-        self.node = node  # type: ast.stmt
-        self.block_type = block_type  # type: ActNodeType
+        self.node = node
+        self.block_type = block_type
 
     @classmethod
     def build_body(cls: Type[AN], body: List[ast.stmt]) -> List:
@@ -29,7 +29,7 @@ class ActNode:
         Note:
             Return type is probably ``-> List[AN]``, but can't get it to pass.
         """
-        act_nodes = []  # type: List[ActNode]
+        act_nodes: List[ActNode] = []
         for child_node in body:
             act_nodes += ActNode.build(child_node)
         return act_nodes
@@ -50,9 +50,8 @@ class ActNode:
         if node_is_unittest_raises(node):
             return [cls(node, ActNodeType.unittest_raises)]
 
-        token = node.first_token  # type: ignore
         # Check if line marked with '# act'
-        if token.line.strip().endswith('# act'):
+        if get_first_token(node).line.strip().endswith('# act'):
             return [cls(node, ActNodeType.marked_act)]
 
         # Recurse (downwards) if it's a context manager

--- a/src/flake8_aaa/function.py
+++ b/src/flake8_aaa/function.py
@@ -33,15 +33,15 @@ class Function:
             node
             file_lines: Lines of file under test.
         """
-        self.node = node  # type: ast.FunctionDef
-        self.first_line_no = get_first_token(self.node).start[0]  # type: int
-        end = get_last_token(self.node).end[0]  # type: int
-        self.lines = file_lines[self.first_line_no - 1:end]  # type: List[str]
-        self.arrange_block = None  # type: Optional[Block]
-        self.act_node = None  # type: Optional[ActNode]
-        self.act_block = None  # type: Optional[Block]
-        self.assert_block = None  # type: Optional[Block]
-        self.line_markers = LineMarkers(self.lines, self.first_line_no)  # type: LineMarkers
+        self.node = node
+        self.first_line_no: int = get_first_token(self.node).start[0]
+        end: int = get_last_token(self.node).end[0]
+        self.lines: List[str] = file_lines[self.first_line_no - 1:end]
+        self.arrange_block: Optional[Block] = None
+        self.act_node: Optional[ActNode] = None
+        self.act_block: Optional[Block] = None
+        self.assert_block: Optional[Block] = None
+        self.line_markers = LineMarkers(self.lines, self.first_line_no)
 
     def __str__(self, errors: Optional[List[AAAError]] = None) -> str:
         out = '------+------------------------------------------------------------------------\n'

--- a/src/flake8_aaa/helpers.py
+++ b/src/flake8_aaa/helpers.py
@@ -53,8 +53,8 @@ class TestFuncLister(ast.NodeVisitor):
 
     def __init__(self, skip_noqa: bool):
         super(TestFuncLister, self).__init__()
-        self.skip_noqa = skip_noqa  # type: bool
-        self._found_funcs = []  # type: List[ast.FunctionDef]
+        self.skip_noqa = skip_noqa
+        self._found_funcs: List[ast.FunctionDef] = []
 
     def visit_FunctionDef(self, node):
         if node.name.startswith('test'):
@@ -106,9 +106,7 @@ def node_is_pytest_raises(node: ast.AST) -> bool:
         bool: ``node`` corresponds to a With node where the context manager is
         ``pytest.raises``.
     """
-    # `.first_token` is added by asttokens
-    token = node.first_token  # type: ignore
-    return isinstance(node, ast.With) and token.line.strip().startswith('with pytest.raises')
+    return isinstance(node, ast.With) and get_first_token(node).line.strip().startswith('with pytest.raises')
 
 
 def node_is_unittest_raises(node: ast.AST) -> bool:
@@ -116,9 +114,7 @@ def node_is_unittest_raises(node: ast.AST) -> bool:
     ``node`` corresponds to a With node where the context manager is unittest's
     ``self.assertRaises``.
     """
-    # `.first_token` is added by asttokens
-    token = node.first_token  # type: ignore
-    return isinstance(node, ast.With) and token.line.strip().startswith('with self.assertRaises')
+    return isinstance(node, ast.With) and get_first_token(node).line.strip().startswith('with self.assertRaises')
 
 
 def node_is_noop(node: ast.AST) -> bool:

--- a/src/flake8_aaa/line_markers.py
+++ b/src/flake8_aaa/line_markers.py
@@ -13,18 +13,18 @@ class LineMarkers(list):
 
     def __init__(self, lines: typing.List[str], fn_offset: int) -> None:
         super().__init__([LineType.unprocessed] * len(lines))
-        self.lines = lines  # type: typing.List[str]
-        self.fn_offset = fn_offset  # type: int
+        self.lines = lines
+        self.fn_offset = fn_offset
 
-    @typing.overload  # noqa: F811
+    @typing.overload
     def __setitem__(self, key: int, value: typing.Any) -> None:
         pass
 
-    @typing.overload  # noqa: F811
+    @typing.overload
     def __setitem__(self, s: slice, o: typing.Iterable) -> None:
         pass
 
-    def __setitem__(self, key, value):  # noqa: F811
+    def __setitem__(self, key, value):
         """
         Extended version of setitem to assert that item being replaced is
         always an unprocessed line. If the item being replaced is blank line,

--- a/src/flake8_aaa/multi_node_block.py
+++ b/src/flake8_aaa/multi_node_block.py
@@ -13,7 +13,7 @@ class MultiNodeBlock(metaclass=ABCMeta):
         pass
 
     def __init__(self) -> None:
-        self.nodes = []  # type: List[ast.AST]
+        self.nodes: List[ast.AST] = []
 
     @abstractmethod
     def add_node(self, node: ast.AST) -> bool:


### PR DESCRIPTION
Refactor now that py35 is not supported.

* Use `NodeVisitor` to properly find lines that are strings.
* Clean out py35 type hint comments - use type annotations where needed.
* Properly wrap uses of `node.first_token` to use `get_first_token(node)` helper to keep type ignorance in one place.