### PR TITLE
Fix marking of act block on multiple lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Unreleased_
 See also `latest documentation
 <https://flake8-aaa.readthedocs.io/en/latest/#__unreleased_marker__>`_.
 
+Fixed
+.....
+
+* Fix marking of act blocks on multiple lines - allow ``# act`` markers to be
+  found on the last line of possible multi line act blocks. `#165
+  <https://github.com/jamescooke/flake8-aaa/issues/165>`_
+
 0.11.2_ - 2021/04/22
 --------------------
 

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -10,7 +10,7 @@ Python
 Works with Python 3.
 
 Flake8-AAA is fully compatible and tested against the latest versions of Python
-3. Currently that's 3.6, 3.7 and 3.8.
+3. Currently that's 3.6, 3.7, 3.8 and 3.9.
 
 The following versions of Python are no longer supported:
 

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -41,10 +41,25 @@ pin it with a test::
 
     assert result is None
 
-If you can not assign a ``result``, then mark the end of the line considered
-the Act block with ``# act`` (case insensitive)::
+However, if your action's ``None`` return value is type-hinted ``action() ->
+None``, then ``mypy`` will complain if you try to assign a result. In this
+case, or any other where a you can not assign a ``result``, then mark the end
+of the line considered the Act block with ``# act`` (case insensitive)::
 
     data['new_key'] = 1  # act
+
+If the action spans multiple lines, then it can be marked with ``# act`` on the
+first or last line. Both of the following will work::
+
+    validate_row(  # act
+        {"total_number_of_users": "1", "number_of_new_users": "0"},
+        ["total_number_of_users", "number_of_new_users"],
+    )
+
+    validate_row(
+        {"total_number_of_users": "1", "number_of_new_users": "0"},
+        ["total_number_of_users", "number_of_new_users"],
+    )  # act
 
 Code blocks wrapped in ``pytest.raises()`` and ``unittest.assertRaises()``
 context managers are recognised as Act blocks.

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,21 @@
+Examples
+========
+
+Test examples used to test Flake8-AAA.
+
+Black formatted examples
+------------------------
+
+To update the examples formatted with Black in ``good/black`` (run from project
+root)::
+
+    pip install -r requirements/examples.txt
+    make black_examples fixlintexamples
+
+Then check them with "local" lint::
+
+    make lintexamples
+
+Or run tox on the "example" environments::
+
+    tox -l | ag example

--- a/examples/good/black/test_comments.py
+++ b/examples/good/black/test_comments.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 # Example from AAA06 doc:
 # * inline comment is OK for marking
@@ -25,6 +25,59 @@ def test_ignore_typing() -> None:
 
     assert result is None
     assert shopping == ["cabbages", "bananas", "apples"]
+
+
+# Example from docs:
+# mark the end of the line considered the Act block with ``# act`` (case insensitive)
+def test_Act() -> None:
+    """
+    Reverse shopping list operates in place
+
+    AAA: act can be marked with "# Act"
+    """
+    shopping = ["apples", "bananas", "cabbages"]
+
+    shopping.reverse()  # Act
+
+    assert shopping == ["cabbages", "bananas", "apples"]
+
+
+# Example from docs:
+# can be marked with ``# act`` on the first or last line.
+
+
+def test_mark_first_line() -> None:
+    """
+    Item can be added to list
+
+    AAA: first line of act can be marked
+    """
+    shopping = ["apples", "bananas", "cabbages"]
+
+    shopping.append(  # act
+        "dill",
+    )
+
+    assert shopping == ["apples", "bananas", "cabbages", "dill"]
+
+
+def test_mark_last_line() -> None:
+    """
+    Item can be added to list
+
+    AAA: last line of act can be marked
+    """
+    shopping: List[Union[str, List[str]]] = ["apples", "bananas", "cabbages"]
+
+    shopping.append(
+        [
+            "dill",
+            "eggs",
+            "fennel",
+        ]
+    )  # act
+
+    assert shopping == ["apples", "bananas", "cabbages", ["dill", "eggs", "fennel"]]
 
 
 # Comments are OK in Arrange and Assert.

--- a/examples/good/black/test_user_options.py
+++ b/examples/good/black/test_user_options.py
@@ -7,7 +7,9 @@ from tests.adapters.filesystem import FakeFileSystem
 def test_ini_file_reader(filename, contents, expected_options):
     settings.configure(
         FILE_SYSTEM=FakeFileSystem(
-            content_map={f"/path/to/folder/{filename}": contents},
+            content_map={
+                f"/path/to/folder/{filename}": contents,
+            },
             working_directory="/path/to/folder",
         )
     )

--- a/examples/good/test_comments.py
+++ b/examples/good/test_comments.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 # Example from AAA06 doc:
 # * inline comment is OK for marking
@@ -67,7 +67,7 @@ def test_mark_last_line() -> None:
 
     AAA: last line of act can be marked
     """
-    shopping = ['apples', 'bananas', 'cabbages']
+    shopping: List[Union[str, List[str]]] = ['apples', 'bananas', 'cabbages']
 
     shopping.append([
         'dill',

--- a/examples/good/test_comments.py
+++ b/examples/good/test_comments.py
@@ -31,13 +31,51 @@ def test_ignore_typing() -> None:
 # mark the end of the line considered the Act block with ``# act`` (case insensitive)
 def test_Act() -> None:
     """
-    Reverse shopping list operates in place (test of "# Act" marking)
+    Reverse shopping list operates in place
+
+    AAA: act can be marked with "# Act"
     """
     shopping = ['apples', 'bananas', 'cabbages']
 
     shopping.reverse()  # Act
 
     assert shopping == ['cabbages', 'bananas', 'apples']
+
+
+# Example from docs:
+# can be marked with ``# act`` on the first or last line.
+
+
+def test_mark_first_line() -> None:
+    """
+    Item can be added to list
+
+    AAA: first line of act can be marked
+    """
+    shopping = ['apples', 'bananas', 'cabbages']
+
+    shopping.append(  # act
+        'dill',
+    )
+
+    assert shopping == ['apples', 'bananas', 'cabbages', 'dill']
+
+
+def test_mark_last_line() -> None:
+    """
+    Item can be added to list
+
+    AAA: last line of act can be marked
+    """
+    shopping = ['apples', 'bananas', 'cabbages']
+
+    shopping.append([
+        'dill',
+        'eggs',
+        'fennel',
+    ])  # act
+
+    assert shopping == ['apples', 'bananas', 'cabbages', ['dill', 'eggs', 'fennel']]
 
 
 # Comments are OK in Arrange and Assert.

--- a/src/flake8_aaa/act_node.py
+++ b/src/flake8_aaa/act_node.py
@@ -2,7 +2,13 @@ import ast
 import re
 from typing import List, Type, TypeVar
 
-from .helpers import get_first_token, node_is_pytest_raises, node_is_result_assignment, node_is_unittest_raises
+from .helpers import (
+    get_first_token,
+    get_last_token,
+    node_is_pytest_raises,
+    node_is_result_assignment,
+    node_is_unittest_raises,
+)
 from .types import ActNodeType
 
 AN = TypeVar('AN', bound='ActNode')  # Place holder for ActNode instances
@@ -42,6 +48,9 @@ class ActNode:
         Starting at this ``node``, check if it's an act node. If it's a context
         manager, recurse into child nodes.
 
+        Finds "# act" marked Act nodes where the marker is on the first or last
+        line of the node.
+
         Returns:
             List of all act nodes found.
         """
@@ -52,8 +61,11 @@ class ActNode:
         if node_is_unittest_raises(node):
             return [cls(node, ActNodeType.unittest_raises)]
 
-        # Check if line marked with '# act'
-        if act_pattern.search(get_first_token(node).line.strip()):
+        # Check if first or last line is marked with '# act'
+        if (
+            act_pattern.search(get_first_token(node).line.strip())
+            or act_pattern.search(get_last_token(node).line.strip())
+        ):
             return [cls(node, ActNodeType.marked_act)]
 
         # Recurse (downwards) if it's a context manager

--- a/tests/act_node/test_build.py
+++ b/tests/act_node/test_build.py
@@ -62,6 +62,22 @@ def test(expected_type, first_node_with_tokens):
 
 
 @pytest.mark.parametrize(
+    'code_str, expected_type', [
+        # ('result = do_thing(\n    1,\n)', ActNodeType.result_assignment),
+        ('do_thing(\n    1,\n)  # Act', ActNodeType.marked_act),
+    ]
+)
+def test_multi_line(expected_type, first_node_with_tokens):
+    result = ActNode.build(first_node_with_tokens)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], ActNode)
+    assert result[0].node == first_node_with_tokens
+    assert result[0].block_type == expected_type
+
+
+@pytest.mark.parametrize(
     'code_str', [
         "with mock.patch('stats.deletion_manager.deleted'):\n    result = existing_user.delete()",
     ]

--- a/tests/act_node/test_build.py
+++ b/tests/act_node/test_build.py
@@ -63,11 +63,11 @@ def test(expected_type, first_node_with_tokens):
 
 @pytest.mark.parametrize(
     'code_str, expected_type', [
-        # ('result = do_thing(\n    1,\n)', ActNodeType.result_assignment),
+        ('do_thing(  # act\n    1,\n)', ActNodeType.marked_act),
         ('do_thing(\n    1,\n)  # Act', ActNodeType.marked_act),
     ]
 )
-def test_multi_line(expected_type, first_node_with_tokens):
+def test_multi_line(expected_type: ActNodeType, first_node_with_tokens):
     result = ActNode.build(first_node_with_tokens)
 
     assert isinstance(result, list)

--- a/tests/function/test_load_act_node.py
+++ b/tests/function/test_load_act_node.py
@@ -50,6 +50,24 @@ def test_act_marker_case(function):
     assert result.node.first_token.line == '    x = y + 1  # Act\n'
 
 
+@pytest.mark.parametrize('code_str', ['''
+def test() -> None:
+   validate_row(
+       {"total_number_of_users": "1", "number_of_new_users": "0"},
+       ["total_number_of_users", "number_of_new_users"],
+   )  # act
+'''])
+def test_act_marker_multi_line(function):
+    """
+    Act marker can be at end of bunch of lines
+    """
+    result = function.load_act_node()
+
+    assert isinstance(result, ActNode)
+    assert result.block_type == ActNodeType.marked_act
+    assert result.node.first_token.line == '    x = y + 1  # Act\n'
+
+
 @pytest.mark.parametrize(
     'code_str',
     [


### PR DESCRIPTION
Fixes #165 

## Adds

* Second check for `# act` marker on last line of possible act node.
* More info on rebuilding Black formatted examples

## Changes

* Adjust act node building to recurse first, then check for `# act` markers from the bottom of the tree.