### PR TITLE
Bump to 0.17.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Changed
   deprecated in Python 3.8. `Issue 239
   <https://github.com/jamescooke/flake8-aaa/issues/239>`_.
 
+* 📕 Version signatures now run on Python 3.14, upgraded from Python 3.12.
+
 0.17.1_ - 2025/10/24
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Unreleased_
 See also `latest documentation
 <https://flake8-aaa.readthedocs.io/en/latest/#__unreleased_marker__>`_.
 
+0.17.2_ - 2025/10/25
+--------------------
+
 Added
 .....
 
@@ -669,7 +672,8 @@ Fixed
 
 Initial alpha release.
 
-.. _Unreleased: https://github.com/jamescooke/flake8-aaa/compare/v0.17.1...HEAD
+.. _Unreleased: https://github.com/jamescooke/flake8-aaa/compare/v0.17.2...HEAD
+.. _0.17.2: https://github.com/jamescooke/flake8-aaa/compare/v0.17.2...v0.17.2
 .. _0.17.1: https://github.com/jamescooke/flake8-aaa/compare/v0.17.0...v0.17.1
 .. _0.17.0: https://github.com/jamescooke/flake8-aaa/compare/v0.16.0...v0.17.0
 .. _0.16.0: https://github.com/jamescooke/flake8-aaa/compare/v0.15.0...v0.16.0

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs:
 # Generate version signature used in README.rst
 .PHONY: signature
 signature:
-	tox exec -e py312-meta_plugin_dogfood -- flake8 --version
+	tox exec -e py314-meta_plugin_dogfood -- flake8 --version
 
 .PHONY: clean
 clean:

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,9 @@ string:
 
 .. code-block::
 
-    6.1.0 (flake8-aaa: 0.17.0, mccabe: 0.7.0, pycodestyle: 2.11.1, pyflakes: 3.1.0) CPython 3.11.6 on Linux
+    7.3.0 (flake8-aaa: 0.17.2, mccabe: 0.7.0, pycodestyle: 2.14.0, pyflakes: 3.4.0) CPython 3.14.0 on Linux
 
-The ``flake8-aaa: 0.17.0`` part tells you that Flake8-AAA was installed
+The ``flake8-aaa: 0.17.2`` part tells you that Flake8-AAA was installed
 successfully and its checks will be used by Flake8.
 
 Further reading:

--- a/src/flake8_aaa/__about__.py
+++ b/src/flake8_aaa/__about__.py
@@ -1,9 +1,9 @@
 __short_name__ = 'aaa'
 __iam__ = f'flake8-{__short_name__}'
-__version__ = '0.17.1'
+__version__ = '0.17.2'
 
 __author__ = 'James Cooke'
-__copyright__ = f'2018 - 2023, {__author__}'
+__copyright__ = f'2018 - 2025, {__author__}'
 
 __description__ = 'A Flake8 plugin that checks Python tests follow the Arrange-Act-Assert pattern'
 __email__ = 'github@jamescooke.info'


### PR DESCRIPTION
- **Migrate version signatures to Py3.14 and update README**
- **Bump to 0.17.2**
